### PR TITLE
Fix multi language selection

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -19,7 +19,7 @@ export default {
       findLanguageTags: textEditor => {
         let languages = []
         textEditor.scan(magicSpellCheckPattern, ({match, stop}) => {
-          languages = match[1].split(/(?:\s,)+/)
+          languages = match[1].split(/\s*,\s*/)
           stop()
         })
         return languages


### PR DESCRIPTION
This makes `%!TeX spellcheck = de-DE,en-US` correctly select German and English as languages.