### PR TITLE
Add new magic comment's scope to checkedScopes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -29,6 +29,7 @@ export default {
         'comment.line.percentage.tex': checkComments,
         'comment.line.percentage.latex': checkComments,
         'comment.line.percentage.directive.texshop.tex': false,
+        'comment.line.percentage.magic.tex': false,
         'constant.character.latex': false,
         'constant.other.reference.citation.latex': false,
         'constant.other.reference.latex': false,


### PR DESCRIPTION
As can be seen in yudai-nkt/language-tex@08ee8df32f8187b54d1d93c4237d9768f19149f5, scope name was renamed to `comment.line.percentage.magic.tex` because magic comments are used in TeX IDEs other than TeXShop. Previous name is still available to keep backward compatibility (there are `language-latex` users also).