### PR TITLE
Fix LaTeX units filtering

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -82,7 +82,7 @@ export default {
         'text.tex': true,
         'variable.parameter.function.latex': false
       },
-      getRanges: (textEditor, ranges) => {
+      filterRanges: (textEditor, ranges) => {
         let ignoredRanges = []
         for (const searchRange of ranges) {
           textEditor.scanInBufferRange(ignorePattern, searchRange, ({range}) => {


### PR DESCRIPTION
The field name was changed from `getRanges` to `filterRanges` in linter-spell 3 years ago: https://github.com/AtomLinter/linter-spell/commit/0a04106043e64a01772ab2634bef424fcc41a682#diff-16b7d75b70953cbf4755508170f2f24c

This fix #38 for me.