### PR TITLE
Allowing linter-spell-latex to activate and to ignore most LaTeX syntax in spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and [language-latex](https://atom.io/packages/language-latex).
 
 The package has support for the following TeX Magic comment
 
-*   `%!TeX spellcheck = en-US,en-DE` Select languages
+*   `%!TeX spellcheck = en-US, de-DE` Select languages
 
 ## Status
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,7 @@
 import { CompositeDisposable } from 'atom'
 
 const magicSpellCheckPattern = /^%\s*!TEX\s+spellcheck\s*=\s*(.*)$/im
-const ignorePattern = /[0-9]+(pt|mm|cm|in|ex|em|bp|pc|dd|cc|sp)/
+const ignorePattern = /([-0-9.]+ ?(pt|mm|cm|in|ex|em|bp|pc|dd|cc|sp))|(\\(documentclass|usepackage|input|chapter|section|subsection|subsubsection|paragraph|begin|end|cite|cited|citep|ref|vspace|hspace|includegraphics|label|tag|bibliographystyle|biboptions)\*?(\[.+?\])?(\{.+?\})?)(\[.+?\])?|(\\\w+)/
 const grammarScopes = ['text.tex', 'text.tex.latex', 'text.tex.latex.memoir', 'text.tex.latex.beamer']
 
 export default {
@@ -82,7 +82,7 @@ export default {
         'text.tex': true,
         'variable.parameter.function.latex': false
       },
-      getRanges: (textEditor, ranges) => {
+      filterRanges: (textEditor, ranges) => {
         let ignoredRanges = []
         for (const searchRange of ranges) {
           textEditor.scanInBufferRange(ignorePattern, searchRange, ({range}) => {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,6 @@
   "package-deps": [
     "linter-spell"
   ],
-  "activationHooks": [
-    "language-latex:grammar-used",
-    "language-tex:grammar-used",
-    "language-latex2e:grammar-used"
-  ],
   "standard": {
     "parser": "babel-eslint",
     "globals": [


### PR DESCRIPTION
Changed outdated `getRanges` method in LaTeX grammar to `filterRanges` and provided a more rigorous regex for excluding common LaTeX syntax elements.

Since the buffer is split into different ranges for spell checking we can still get false-positives, e.g., in `\begin{footnotesize}`, `footnotesize` may or may not be marked as a spelling error depending on whether it is in the same range as `\begin{` and `}`.
However, this PR greatly reduces these false-positives compared to before
